### PR TITLE
Add estimatedByteSizes to merges kicked off by IndexWriter.addIndexes…

### DIFF
--- a/lucene/CHANGES.txt
+++ b/lucene/CHANGES.txt
@@ -81,6 +81,8 @@ Bug Fixes
 * GITHUB#14847: Allow Faiss vector format to index >2GB of vectors per-field per-segment by using MemorySegment APIs
   (instead of ByteBuffer) to copy bytes to native memory. (Kaival Parikh)
 
+* GITHUB#15120: Add estimatedByteSizes to merges kicked off by IndexWriter.addIndexes(CodecReader[]) (Craig Perkins)
+
 Changes in Runtime Behavior
 ---------------------
 * GITHUB#14187: The query cache is now disabled by default. (Adrien Grand)

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -21,6 +21,7 @@ import static org.apache.lucene.util.ByteBlockPool.BYTE_BLOCK_SIZE;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -3287,8 +3288,8 @@ public class IndexWriter
     public void registerMerge(MergePolicy.OneMerge merge) {
       try {
         addEstimatedBytesToMerge(merge);
-      } catch (IOException _) {
-        // ignore and append to pending merges
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
       }
       synchronized (IndexWriter.this) {
         pendingAddIndexesMerges.add(merge);

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3284,8 +3284,10 @@ public class IndexWriter
       this.writer = writer;
     }
 
-    public void registerMerge(MergePolicy.OneMerge merge) throws IOException {
-      addEstimatedBytesToMerge(merge);
+    public void registerMerge(MergePolicy.OneMerge merge){
+      try {
+        addEstimatedBytesToMerge(merge);
+      } catch (IOException ignore) { }
       synchronized (IndexWriter.this) {
         pendingAddIndexesMerges.add(merge);
       }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3284,7 +3284,7 @@ public class IndexWriter
       this.writer = writer;
     }
 
-    public void registerMerge(MergePolicy.OneMerge merge){
+    public void registerMerge(MergePolicy.OneMerge merge) {
       try {
         addEstimatedBytesToMerge(merge);
       } catch (IOException ignore) {

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4782,6 +4782,7 @@ public class IndexWriter
     closeMergeReaders(merge, true, false);
   }
 
+  /** Compute {@code estimatedMergeBytes} and {@code totalMergeBytes} for a merge. */
   public void addEstimatedBytesToMerge(MergePolicy.OneMerge merge) throws IOException {
     assert merge.estimatedMergeBytes == 0;
     assert merge.totalMergeBytes == 0;

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3287,7 +3287,9 @@ public class IndexWriter
     public void registerMerge(MergePolicy.OneMerge merge){
       try {
         addEstimatedBytesToMerge(merge);
-      } catch (IOException ignore) { }
+      } catch (IOException ignore) {
+        ignore.printStackTrace(System.err);
+      }
       synchronized (IndexWriter.this) {
         pendingAddIndexesMerges.add(merge);
       }

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -3287,8 +3287,8 @@ public class IndexWriter
     public void registerMerge(MergePolicy.OneMerge merge) {
       try {
         addEstimatedBytesToMerge(merge);
-      } catch (IOException ignore) {
-        ignore.printStackTrace(System.err);
+      } catch (IOException _) {
+        // ignore and append to pending merges
       }
       synchronized (IndexWriter.this) {
         pendingAddIndexesMerges.add(merge);

--- a/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java
@@ -4783,7 +4783,7 @@ public class IndexWriter
   }
 
   /** Compute {@code estimatedMergeBytes} and {@code totalMergeBytes} for a merge. */
-  public void addEstimatedBytesToMerge(MergePolicy.OneMerge merge) throws IOException {
+  void addEstimatedBytesToMerge(MergePolicy.OneMerge merge) throws IOException {
     assert merge.estimatedMergeBytes == 0;
     assert merge.totalMergeBytes == 0;
     for (SegmentCommitInfo info : merge.segments) {

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
@@ -461,4 +461,31 @@ public class TestIndexWriterMerging extends LuceneTestCase {
 
     directory.close();
   }
+
+  public void testAddEstimatedBytesToMerge() throws IOException {
+    Directory dir = newDirectory();
+    IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random()))
+        .setMergePolicy(NoMergePolicy.INSTANCE));
+
+    Document doc = new Document();
+    doc.add(newTextField("field", "content", Field.Store.YES));
+    for (int i = 0; i < 10; i++) {
+      writer.addDocument(doc);
+    }
+    writer.flush();
+
+
+    // Create a merge with the segments
+    SegmentInfos segmentInfos = writer.cloneSegmentInfos();
+    MergePolicy.OneMerge merge = new MergePolicy.OneMerge(segmentInfos.asList());
+
+    writer.addEstimatedBytesToMerge(merge);
+
+    assertTrue(merge.estimatedMergeBytes > 0);
+    assertTrue(merge.totalMergeBytes > 0);
+    assertTrue(merge.estimatedMergeBytes <= merge.totalMergeBytes);
+
+    writer.close();
+    dir.close();
+  }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
@@ -463,31 +463,33 @@ public class TestIndexWriterMerging extends LuceneTestCase {
   }
 
   public void testAddEstimatedBytesToMerge() throws IOException {
-    Directory dir = newDirectory();
-    IndexWriter writer =
-        new IndexWriter(
-            dir,
-            newIndexWriterConfig(new MockAnalyzer(random()))
-                .setMergePolicy(NoMergePolicy.INSTANCE));
+    try (Directory dir = newDirectory();
+        IndexWriter writer =
+            new IndexWriter(
+                dir,
+                newIndexWriterConfig(new MockAnalyzer(random()))
+                    .setMergePolicy(NoMergePolicy.INSTANCE))) {
 
-    Document doc = new Document();
-    doc.add(newTextField("field", "content", Field.Store.YES));
-    for (int i = 0; i < 10; i++) {
-      writer.addDocument(doc);
+      Document doc = new Document();
+      doc.add(newTextField("field", "content", Field.Store.YES));
+
+      for (int i = 0; i < 10; i++) {
+
+        writer.addDocument(doc);
+      }
+      writer.flush();
+
+      // Create a merge with the segments
+      SegmentInfos segmentInfos = writer.cloneSegmentInfos();
+      MergePolicy.OneMerge merge = new MergePolicy.OneMerge(segmentInfos.asList());
+
+      writer.addEstimatedBytesToMerge(merge);
+
+      assertTrue(merge.estimatedMergeBytes > 0);
+
+      assertTrue(merge.totalMergeBytes > 0);
+
+      assertTrue(merge.estimatedMergeBytes <= merge.totalMergeBytes);
     }
-    writer.flush();
-
-    // Create a merge with the segments
-    SegmentInfos segmentInfos = writer.cloneSegmentInfos();
-    MergePolicy.OneMerge merge = new MergePolicy.OneMerge(segmentInfos.asList());
-
-    writer.addEstimatedBytesToMerge(merge);
-
-    assertTrue(merge.estimatedMergeBytes > 0);
-    assertTrue(merge.totalMergeBytes > 0);
-    assertTrue(merge.estimatedMergeBytes <= merge.totalMergeBytes);
-
-    writer.close();
-    dir.close();
   }
 }

--- a/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
+++ b/lucene/core/src/test/org/apache/lucene/index/TestIndexWriterMerging.java
@@ -464,8 +464,11 @@ public class TestIndexWriterMerging extends LuceneTestCase {
 
   public void testAddEstimatedBytesToMerge() throws IOException {
     Directory dir = newDirectory();
-    IndexWriter writer = new IndexWriter(dir, newIndexWriterConfig(new MockAnalyzer(random()))
-        .setMergePolicy(NoMergePolicy.INSTANCE));
+    IndexWriter writer =
+        new IndexWriter(
+            dir,
+            newIndexWriterConfig(new MockAnalyzer(random()))
+                .setMergePolicy(NoMergePolicy.INSTANCE));
 
     Document doc = new Document();
     doc.add(newTextField("field", "content", Field.Store.YES));
@@ -473,7 +476,6 @@ public class TestIndexWriterMerging extends LuceneTestCase {
       writer.addDocument(doc);
     }
     writer.flush();
-
 
     // Create a merge with the segments
     SegmentInfos segmentInfos = writer.cloneSegmentInfos();


### PR DESCRIPTION
### Description

This PR abstracts the logic to add estimatedByteSizes on merges to a method called `addEstimatedBytesToMerge` so that it can be re-used in multiple places.

Resolves https://github.com/apache/lucene/issues/14993
